### PR TITLE
Fix a panic using a When.ThenReturn

### DIFF
--- a/registry/reporter.go
+++ b/registry/reporter.go
@@ -187,7 +187,13 @@ func (e *EnrichedReporter) ReportInvalidReturnValues(instanceType reflect.Type, 
 		outTypesSB.WriteString("(")
 	}
 	for i := 0; i < len(ret); i++ {
-		outTypesSB.WriteString(reflect.ValueOf(ret[i]).Type().String())
+		of := reflect.ValueOf(ret[i])
+		if of.Kind() == reflect.Invalid {
+			outTypesSB.WriteString("nil")
+		} else {
+			outTypesSB.WriteString(of.Type().String())
+		}
+
 		if i != len(ret)-1 {
 			outTypesSB.WriteString(", ")
 		}

--- a/tests/when/when_double_test.go
+++ b/tests/when/when_double_test.go
@@ -9,6 +9,7 @@ import (
 
 type WhenDoubleInterface interface {
 	Foo(a int) (int, error)
+	FooNullable(a int) (*int, error)
 }
 
 func TestWhenDoubleRet(t *testing.T) {

--- a/tests/when/when_test.go
+++ b/tests/when/when_test.go
@@ -9,6 +9,7 @@ import (
 type WhenInterface interface {
 	Foo(a int) (int, string)
 	Bar(a int, b string, c string) (int, string)
+	NullableBar(a int, b string, c string) (*int, *string)
 	Empty() int
 	RespondWithMock() Nested
 	RespondWithSlice() []int
@@ -73,6 +74,16 @@ func TestNoMatchersAreExactOnReturn(t *testing.T) {
 	i, s := m.Bar(10, "test1", "test2")
 	r.AssertEqual(10, i)
 	r.AssertEqual("2", s)
+}
+
+func TestIncorrectNumberReturnNullable(t *testing.T) {
+	r := common.NewMockReporter(t)
+	SetUp(r)
+	m := Mock[WhenInterface]()
+	When(m.NullableBar(10, "test1", "test2")).ThenReturn(nil)
+	_, _ = m.NullableBar(10, "test1", "test2")
+	r.AssertError()
+	r.ErrorContains("invalid return values")
 }
 
 func TestNoMatchersAreExactOnAnswer(t *testing.T) {


### PR DESCRIPTION
Fix a panic using a When.ThenReturn with incorrect number of return elements including an untyped nil