### PR TITLE
added golangci lint configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,9 @@ jobs:
           go-version-file: go.mod
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.56.2
 
   CodeQL:
     needs: Lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,27 @@
+run:
+  timeout: "10m"
+linters:
+  disable-all: true
+  enable:
+    # Format
+    - "gofumpt" # Gofumpt checks whether code was gofumpt-ed. Which is a superset of gofmt that handles some cases that gofmt missed.
+    - "gci" # Gci controls Go package import order and makes it always deterministic.
+    - "asciicheck" # Checks that all code identifiers does not have non-ASCII symbols in the name.
+    - "bidichk" # Checks for dangerous unicode character sequences.
+    # Error
+    - "errcheck"
+    # Simplify
+    - "gosimple"
+    - "govet"
+    - "ineffassign"
+    - "staticcheck"
+    - "unused"
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/ovechkin-dm/mockio)
+      - blank
+      - dot
+      - alias

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+all: gofumpt import lint
+
+lint:
+	golangci-lint run ./...
+
 gofumpt:
 	gofumpt -l -w .
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 all: gofumpt import lint
 
+init:
+	go install mvdan.cc/gofumpt@v0.6.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
+	go install github.com/daixiang0/gci@v0.12.3
+
 lint:
 	golangci-lint run ./...
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+gofumpt:
+	gofumpt -l -w .
+
+import:
+	gci write --skip-generated -s standard -s default -s "prefix(github.com/ovechkin-dm/mockio)" -s blank -s dot -s alias .

--- a/mock/api.go
+++ b/mock/api.go
@@ -3,10 +3,11 @@ package mock
 import (
 	"context"
 	"fmt"
-	"github.com/ovechkin-dm/mockio/matchers"
-	"github.com/ovechkin-dm/mockio/registry"
 	"reflect"
 	"strings"
+
+	"github.com/ovechkin-dm/mockio/matchers"
+	"github.com/ovechkin-dm/mockio/registry"
 )
 
 // SetUp initializes the mock library with the reporter.

--- a/registry/handler.go
+++ b/registry/handler.go
@@ -2,11 +2,13 @@ package registry
 
 import (
 	"fmt"
-	"github.com/ovechkin-dm/go-dyno/pkg/dyno"
-	"github.com/ovechkin-dm/go-dyno/proxy"
-	"github.com/ovechkin-dm/mockio/matchers"
 	"reflect"
 	"sync"
+
+	"github.com/ovechkin-dm/go-dyno/pkg/dyno"
+	"github.com/ovechkin-dm/go-dyno/proxy"
+
+	"github.com/ovechkin-dm/mockio/matchers"
 )
 
 type invocationHandler struct {
@@ -139,7 +141,6 @@ func (h *invocationHandler) VerifyMethod(verifier matchers.MethodVerifier) {
 }
 
 func (h *invocationHandler) DoVerifyMethod(call *MethodCall) []reflect.Value {
-
 	matchersOk := h.validateMatchers(call)
 
 	verifyMatchersOk := true

--- a/registry/matchers.go
+++ b/registry/matchers.go
@@ -2,8 +2,9 @@ package registry
 
 import (
 	"fmt"
-	"github.com/ovechkin-dm/mockio/matchers"
 	"reflect"
+
+	"github.com/ovechkin-dm/mockio/matchers"
 )
 
 func AnyMatcher[T any]() matchers.Matcher[T] {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -2,17 +2,20 @@ package registry
 
 import (
 	"fmt"
-	"github.com/ovechkin-dm/go-dyno/pkg/dyno"
-	"github.com/ovechkin-dm/mockio/matchers"
-	"github.com/ovechkin-dm/mockio/threadlocal"
-
 	"log"
 	"reflect"
 	"sync"
+
+	"github.com/ovechkin-dm/go-dyno/pkg/dyno"
+
+	"github.com/ovechkin-dm/mockio/matchers"
+	"github.com/ovechkin-dm/mockio/threadlocal"
 )
 
-var instance = threadlocal.NewThreadLocal(newRegistry)
-var lock sync.Mutex
+var (
+	instance = threadlocal.NewThreadLocal(newRegistry)
+	lock     sync.Mutex
+)
 
 type Registry struct {
 	mockContext *mockContext
@@ -62,8 +65,8 @@ func Mock[T any]() T {
 func AddMatcher[T any](m matchers.Matcher[T]) {
 	withCheck[any](func() any {
 		w := &matcherWrapper{
-			matcher: untypedMatcher(m),
-			rec:     nil,
+			matcher:    untypedMatcher(m),
+			rec:        nil,
 			stackTrace: NewStackTrace(),
 		}
 		getInstance().mockContext.getState().matchers = append(getInstance().mockContext.getState().matchers, w)
@@ -78,7 +81,7 @@ func AddCaptor[T any](c *captorImpl[T]) {
 			matcher: FunMatcher(fmt.Sprintf("Captor[%s]", tp), func(call []any, a any) bool {
 				return true
 			}),
-			rec: c,
+			rec:        c,
 			stackTrace: NewStackTrace(),
 		}
 		getInstance().mockContext.getState().matchers = append(getInstance().mockContext.getState().matchers, w)

--- a/registry/reporter.go
+++ b/registry/reporter.go
@@ -2,17 +2,17 @@ package registry
 
 import (
 	"fmt"
-	"github.com/ovechkin-dm/go-dyno/proxy"
-	"github.com/ovechkin-dm/mockio/matchers"
 	"reflect"
 	"strings"
+
+	"github.com/ovechkin-dm/go-dyno/proxy"
+
+	"github.com/ovechkin-dm/mockio/matchers"
 )
 
-type panicReporter struct {
-}
+type panicReporter struct{}
 
 func (p *panicReporter) Cleanup(f func()) {
-
 }
 
 func (p *panicReporter) Fatalf(format string, args ...any) {
@@ -64,7 +64,6 @@ func (e *EnrichedReporter) ReportUnregisteredMockVerify(t any) {
 	Example of correct verification:
 		Verify(mock, Times(10)).SomeMethod()`, t)
 	}
-
 }
 
 func (e *EnrichedReporter) ReportInvalidUseOfMatchers(instanceType reflect.Type, call *MethodCall, m []*matcherWrapper) {
@@ -84,7 +83,7 @@ func (e *EnrichedReporter) ReportInvalidUseOfMatchers(instanceType reflect.Type,
 	numActual := len(m)
 	declarationLines := make([]string, 0)
 	for i := range m {
-		declarationLines = append(declarationLines, "\t\t" + m[i].stackTrace.CallerLine())
+		declarationLines = append(declarationLines, "\t\t"+m[i].stackTrace.CallerLine())
 	}
 	decl := strings.Join(declarationLines, "\n")
 	expectedStr := fmt.Sprintf("%v expected, %v recorded:\n", numExpected, numActual)
@@ -160,7 +159,6 @@ func (e *EnrichedReporter) ReportVerifyMethodError(
 	Invocations:
 %v`, err, callStr, sb.String())
 	}
-
 }
 
 func (e *EnrichedReporter) ReportEmptyCaptor() {

--- a/registry/returners.go
+++ b/registry/returners.go
@@ -16,9 +16,7 @@ func ToReturnerDouble[A any, B any](retAll matchers.ReturnerAll) matchers.Return
 	}
 }
 
-type returnerDummyImpl struct {
-
-}
+type returnerDummyImpl struct{}
 
 func (r *returnerDummyImpl) ThenReturn(values ...any) matchers.ReturnerAll {
 	return r

--- a/registry/state.go
+++ b/registry/state.go
@@ -1,12 +1,14 @@
 package registry
 
 import (
-	"github.com/ovechkin-dm/go-dyno/pkg/dyno"
-	"github.com/ovechkin-dm/mockio/matchers"
-	"github.com/ovechkin-dm/mockio/threadlocal"
 	"reflect"
 	"sync"
 	"sync/atomic"
+
+	"github.com/ovechkin-dm/go-dyno/pkg/dyno"
+
+	"github.com/ovechkin-dm/mockio/matchers"
+	"github.com/ovechkin-dm/mockio/threadlocal"
 )
 
 type fiberState struct {

--- a/registry/util.go
+++ b/registry/util.go
@@ -2,17 +2,20 @@ package registry
 
 import (
 	"fmt"
-	"github.com/ovechkin-dm/go-dyno/proxy"
 	"reflect"
 	"runtime/debug"
 	"strings"
+
+	"github.com/ovechkin-dm/go-dyno/proxy"
 )
 
-const PackageName = "github.com/ovechkin-dm/mockio"
-const DynoPackageName = "github.com/ovechkin-dm/go-dyno"
-const TestPackageName = "github.com/ovechkin-dm/mockio/tests"
-const DebugPackage = "runtime/debug.Stack()"
-const GOIDPackageName = "github.com/petermattis/goid"
+const (
+	PackageName     = "github.com/ovechkin-dm/mockio"
+	DynoPackageName = "github.com/ovechkin-dm/go-dyno"
+	TestPackageName = "github.com/ovechkin-dm/mockio/tests"
+	DebugPackage    = "runtime/debug.Stack()"
+	GOIDPackageName = "github.com/petermattis/goid"
+)
 
 func createDefaultReturnValues(m reflect.Method) []reflect.Value {
 	result := make([]reflect.Value, m.Type.NumOut())

--- a/tests/captor/captor_test.go
+++ b/tests/captor/captor_test.go
@@ -1,9 +1,11 @@
 package captor
 
 import (
-	. "github.com/ovechkin-dm/mockio/mock"
-	"github.com/ovechkin-dm/mockio/tests/common"
 	"testing"
+
+	"github.com/ovechkin-dm/mockio/tests/common"
+
+	. "github.com/ovechkin-dm/mockio/mock"
 )
 
 type iface interface {

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -1,13 +1,14 @@
 package check
 
 import (
-	. "github.com/ovechkin-dm/mockio/mock"
-	"github.com/ovechkin-dm/mockio/tests/common"
 	"testing"
+
+	"github.com/ovechkin-dm/mockio/tests/common"
+
+	. "github.com/ovechkin-dm/mockio/mock"
 )
 
-type St struct {
-}
+type St struct{}
 
 func TestNonInterfaceNotAllowed(t *testing.T) {
 	r := common.NewMockReporter(t)
@@ -15,5 +16,3 @@ func TestNonInterfaceNotAllowed(t *testing.T) {
 	_ = Mock[St]()
 	r.AssertError()
 }
-
-

--- a/tests/concurrent/concurrent_test.go
+++ b/tests/concurrent/concurrent_test.go
@@ -1,10 +1,12 @@
 package concurrent
 
 import (
-	. "github.com/ovechkin-dm/mockio/mock"
-	"github.com/ovechkin-dm/mockio/tests/common"
 	"sync"
 	"testing"
+
+	"github.com/ovechkin-dm/mockio/tests/common"
+
+	. "github.com/ovechkin-dm/mockio/mock"
 )
 
 type myInterface interface {

--- a/tests/match/match_test.go
+++ b/tests/match/match_test.go
@@ -1,9 +1,11 @@
 package match
 
 import (
-	. "github.com/ovechkin-dm/mockio/mock"
-	"github.com/ovechkin-dm/mockio/tests/common"
 	"testing"
+
+	"github.com/ovechkin-dm/mockio/tests/common"
+
+	. "github.com/ovechkin-dm/mockio/mock"
 )
 
 type Iface interface {

--- a/tests/mocking/mock_test.go
+++ b/tests/mocking/mock_test.go
@@ -1,9 +1,11 @@
 package mocking
 
 import (
-	. "github.com/ovechkin-dm/mockio/mock"
-	"github.com/ovechkin-dm/mockio/tests/common"
 	"testing"
+
+	"github.com/ovechkin-dm/mockio/tests/common"
+
+	. "github.com/ovechkin-dm/mockio/mock"
 )
 
 type ByteArrInterface interface {

--- a/tests/reporting/error_reporting_test.go
+++ b/tests/reporting/error_reporting_test.go
@@ -1,10 +1,12 @@
 package reporting
 
 import (
-	. "github.com/ovechkin-dm/mockio/mock"
-	"github.com/ovechkin-dm/mockio/tests/common"
 	"sync"
 	"testing"
+
+	"github.com/ovechkin-dm/mockio/tests/common"
+
+	. "github.com/ovechkin-dm/mockio/mock"
 )
 
 type Foo interface {

--- a/tests/returners/returners_test.go
+++ b/tests/returners/returners_test.go
@@ -1,9 +1,11 @@
 package returners
 
 import (
-	. "github.com/ovechkin-dm/mockio/mock"
-	"github.com/ovechkin-dm/mockio/tests/common"
 	"testing"
+
+	"github.com/ovechkin-dm/mockio/tests/common"
+
+	. "github.com/ovechkin-dm/mockio/mock"
 )
 
 type iface interface {

--- a/tests/simple/simple_test.go
+++ b/tests/simple/simple_test.go
@@ -1,9 +1,11 @@
 package simple
 
 import (
-	. "github.com/ovechkin-dm/mockio/mock"
-	"github.com/ovechkin-dm/mockio/tests/common"
 	"testing"
+
+	"github.com/ovechkin-dm/mockio/tests/common"
+
+	. "github.com/ovechkin-dm/mockio/mock"
 )
 
 type myInterface interface {

--- a/tests/variadic/variadic_test.go
+++ b/tests/variadic/variadic_test.go
@@ -1,9 +1,11 @@
 package variadic
 
 import (
-	. "github.com/ovechkin-dm/mockio/mock"
-	"github.com/ovechkin-dm/mockio/tests/common"
 	"testing"
+
+	"github.com/ovechkin-dm/mockio/tests/common"
+
+	. "github.com/ovechkin-dm/mockio/mock"
 )
 
 type myInterface interface {

--- a/tests/verify/verify_test.go
+++ b/tests/verify/verify_test.go
@@ -1,9 +1,11 @@
 package verify
 
 import (
-	. "github.com/ovechkin-dm/mockio/mock"
-	"github.com/ovechkin-dm/mockio/tests/common"
 	"testing"
+
+	"github.com/ovechkin-dm/mockio/tests/common"
+
+	. "github.com/ovechkin-dm/mockio/mock"
 )
 
 type iface interface {

--- a/tests/when/when_double_test.go
+++ b/tests/when/when_double_test.go
@@ -2,9 +2,11 @@ package when
 
 import (
 	"errors"
-	. "github.com/ovechkin-dm/mockio/mock"
-	"github.com/ovechkin-dm/mockio/tests/common"
 	"testing"
+
+	"github.com/ovechkin-dm/mockio/tests/common"
+
+	. "github.com/ovechkin-dm/mockio/mock"
 )
 
 type WhenDoubleInterface interface {

--- a/tests/when/when_single_test.go
+++ b/tests/when/when_single_test.go
@@ -1,9 +1,11 @@
 package when
 
 import (
-	. "github.com/ovechkin-dm/mockio/mock"
-	"github.com/ovechkin-dm/mockio/tests/common"
 	"testing"
+
+	"github.com/ovechkin-dm/mockio/tests/common"
+
+	. "github.com/ovechkin-dm/mockio/mock"
 )
 
 type whenSingleInterface interface {

--- a/tests/when/when_test.go
+++ b/tests/when/when_test.go
@@ -1,9 +1,11 @@
 package when
 
 import (
-	. "github.com/ovechkin-dm/mockio/mock"
-	"github.com/ovechkin-dm/mockio/tests/common"
 	"testing"
+
+	"github.com/ovechkin-dm/mockio/tests/common"
+
+	. "github.com/ovechkin-dm/mockio/mock"
 )
 
 type WhenInterface interface {
@@ -23,8 +25,7 @@ type Nested interface {
 	Foo() int
 }
 
-type WhenStruct struct {
-}
+type WhenStruct struct{}
 
 func (w *WhenStruct) foo() int {
 	return 10
@@ -143,7 +144,7 @@ func TestSliceReturn(t *testing.T) {
 	r := common.NewMockReporter(t)
 	SetUp(r)
 	m1 := Mock[WhenInterface]()
-	expected := []int{1,2,3}
+	expected := []int{1, 2, 3}
 	When(m1.RespondWithSlice()).ThenReturn(expected)
 	result := m1.RespondWithSlice()
 	r.AssertEqual(expected, result)

--- a/threadlocal/threadlocal.go
+++ b/threadlocal/threadlocal.go
@@ -1,8 +1,9 @@
 package threadlocal
 
 import (
-	"github.com/petermattis/goid"
 	"sync"
+
+	"github.com/petermattis/goid"
 )
 
 type ThreadLocal[T any] interface {


### PR DESCRIPTION
added golangci lint configuration file with default linter as well as a few code format linters

- gofumpt : ensure that the files are gofumpted, which is a stricter gofmt that handles a few blind spot of gofmt
- gci : goimports with a bit of configuration to have a predictable order of package
- asciicheck : Checks that all code identifiers does not have non-ASCII symbols in the name.
- bidichk : Checks for dangerous unicode character sequences.