### PR TITLE
feat(mock): Improve SliceEqualUnordered matcher for pointer slice comparisons

### DIFF
--- a/mock/api.go
+++ b/mock/api.go
@@ -224,20 +224,21 @@ func MapContains[K comparable, V any](values ...K) map[K]V {
 //	WhenSingle(myMock.MyMethod(SliceEqualUnordered([]int{2,1}))).ThenReturn("baz")
 func SliceEqualUnordered[T any](values []T) []T {
 	desc := fmt.Sprintf("EqualUnordered(%v)", values)
-	vmap := make(map[any]struct{})
-	for _, v := range values {
-		vmap[v] = struct{}{}
-	}
 	m := registry.FunMatcher(desc, func(m []any, actual []T) bool {
-		if len(vmap) != len(values) {
-			return false
-		}
 		if len(actual) != len(values) {
 			return false
 		}
-		for _, v := range actual {
-			_, ok := vmap[v]
-			if !ok {
+		matched := make([]bool, len(values))
+		for _, actualElem := range actual {
+			found := false
+			for i, expectedElem := range values {
+				if !matched[i] && reflect.DeepEqual(actualElem, expectedElem) {
+					matched[i] = true
+					found = true
+					break
+				}
+			}
+			if !found {
 				return false
 			}
 		}

--- a/tests/match/match_test.go
+++ b/tests/match/match_test.go
@@ -332,3 +332,64 @@ func TestExactNotComparable(t *testing.T) {
 	When(greeter.Greet(Exact(data))).ThenReturn("hello world")
 	greeter.Greet(data)
 }
+
+type PointerSliceInterface interface {
+	Test(m []*int) int
+}
+
+type StructPointerSliceInterface interface {
+	Test(m []*St) int
+}
+
+func TestSliceEqualUnorderedPointerMatch(t *testing.T) {
+	r := common.NewMockReporter(t)
+	ctrl := NewMockController(r)
+	m := Mock[PointerSliceInterface](ctrl)
+	v1, v2, v3 := 1, 2, 3
+	WhenSingle(m.Test(SliceEqualUnordered([]*int{&v1, &v2, &v3}))).ThenReturn(3)
+	a1, a2, a3 := 1, 2, 3
+	ret := m.Test([]*int{&a3, &a2, &a1})
+	r.AssertEqual(3, ret)
+}
+
+func TestSliceEqualUnorderedPointerNoMatch(t *testing.T) {
+	r := common.NewMockReporter(t)
+	ctrl := NewMockController(r)
+	m := Mock[PointerSliceInterface](ctrl)
+	v1, v2, v3 := 1, 2, 3
+	WhenSingle(m.Test(SliceEqualUnordered([]*int{&v1, &v2, &v3}))).ThenReturn(3)
+	a1, a2, a3 := 1, 2, 4
+	ret := m.Test([]*int{&a3, &a2, &a1})
+	r.AssertEqual(0, ret)
+}
+
+func TestSliceEqualUnorderedNilPointer(t *testing.T) {
+	r := common.NewMockReporter(t)
+	ctrl := NewMockController(r)
+	m := Mock[PointerSliceInterface](ctrl)
+	v1, v2 := 1, 2
+	WhenSingle(m.Test(SliceEqualUnordered([]*int{&v1, nil, &v2}))).ThenReturn(3)
+	a1, a2 := 1, 2
+	ret := m.Test([]*int{nil, &a2, &a1})
+	r.AssertEqual(3, ret)
+}
+
+func TestSliceEqualUnorderedStructPointer(t *testing.T) {
+	r := common.NewMockReporter(t)
+	ctrl := NewMockController(r)
+	m := Mock[StructPointerSliceInterface](ctrl)
+	s1, s2 := St{value: 10}, St{value: 20}
+	WhenSingle(m.Test(SliceEqualUnordered([]*St{&s1, &s2}))).ThenReturn(2)
+	a1, a2 := St{value: 10}, St{value: 20}
+	ret := m.Test([]*St{&a2, &a1})
+	r.AssertEqual(2, ret)
+}
+
+func TestSliceEqualUnorderedDuplicates(t *testing.T) {
+	r := common.NewMockReporter(t)
+	ctrl := NewMockController(r)
+	m := Mock[SliceInterface](ctrl)
+	WhenSingle(m.Test(SliceEqualUnordered([]int{1, 1, 2}))).ThenReturn(3)
+	ret := m.Test([]int{2, 1, 1})
+	r.AssertEqual(3, ret)
+}


### PR DESCRIPTION
Fix #100 

- Use reflect.DeepEqual in SliceEqualUnordered