### PR TITLE
Fix mock option imports in documentation examples

### DIFF
--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -8,7 +8,7 @@ package main
 
 import (
 	. "github.com/ovechkin-dm/mockio/v2/mock"
-	"github.com/ovechkin-dm/mockio/mockopts"
+	"github.com/ovechkin-dm/mockio/v2/mockopts"
 	"testing"
 )
 
@@ -31,7 +31,7 @@ package main
 
 import (
 	. "github.com/ovechkin-dm/mockio/v2/mock"
-	"github.com/ovechkin-dm/mockio/mockopts"
+	"github.com/ovechkin-dm/mockio/v2/mockopts"
 	"testing"
 )
 


### PR DESCRIPTION
mock v2 import requires mockopts v2.
It throws compilation exception with mockopts v1.